### PR TITLE
Install L4T r28 v2.0 instead of v1.0

### DIFF
--- a/getKernelSources.sh
+++ b/getKernelSources.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Install the kernel source for L4T
-sudo ./scripts/getKernelSources.sh
+sudo ./scripts/getKernelSources_noGUI.sh

--- a/scripts/getKernelSources_noGUI.sh
+++ b/scripts/getKernelSources_noGUI.sh
@@ -3,7 +3,7 @@ apt-add-repository universe
 apt-get update
 apt-get install qt5-default pkg-config -y
 cd /usr/src
-wget -N http://developer.download.nvidia.com/embedded/L4T/r28_Release_v1.0/BSP/source_release.tbz2
+wget -N https://developer2.download.nvidia.com/embedded/L4T/r28_Release_v2.0/BSP/source_release.tbz2
 tar -xvf source_release.tbz2 sources/kernel_src-tx2.tbz2
 tar -xvf sources/kernel_src-tx2.tbz2
 cd kernel/kernel-4.4

--- a/scripts/getKernelSources_noGUI.sh
+++ b/scripts/getKernelSources_noGUI.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+apt-add-repository universe
+apt-get update
+apt-get install qt5-default pkg-config -y
+cd /usr/src
+wget -N http://developer.download.nvidia.com/embedded/L4T/r28_Release_v1.0/BSP/source_release.tbz2
+tar -xvf source_release.tbz2 sources/kernel_src-tx2.tbz2
+tar -xvf sources/kernel_src-tx2.tbz2
+cd kernel/kernel-4.4
+zcat /proc/config.gz > .config


### PR DESCRIPTION
I created a new script to download the newest version of L4T (r28 at v2.0).
For use on headless setups it also skips the graphical kernel configuration.