### PR TITLE
Jetpack 4.2 / L4T 32.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-18 Jetsonhacks
+Copyright (c) 2017-19 Jetsonhacks
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # buildJetsonTX2Kernel
-Scripts to help build the 4.4.38 kernel and modules onboard the Jetson TX2 (L4T 28.2.1, JetPack 3.2.1). For previous versions, visit the 'tags' section.
+Scripts to help build the 4.9.140 kernel and modules onboard the Jetson TX2 (L4T 32.1.0, JetPack 4.2). For previous versions, visit the 'tags' section.
 
-<em><strong>Note:</strong> The kernel source version must match the version of firmware flashed on the Jetson. For example, the source for the 4.4.38 kernel here is matched with L4T 28.2.1. This kernel compiled using this source tree will not work with newer versions or older versions of L4T, only 28.2.1.</em>
+<em><strong>Note:</strong> The kernel source version must match the version of firmware flashed on the Jetson. For example, the source for the 4.9.140 kernel here is matched with L4T 32.1.0. This kernel compiled using this source tree will not work with newer versions or older versions of L4T, only 32.1.0.</em>
 
 As of this writing, the "official" way to build the Jetson TX2 kernel is to use a cross compiler on a Linux PC. This is an alternative which builds the kernel onboard the Jetson itself. These scripts will download the kernel source to the Jetson TX2, and then compile the kernel and selected modules. The newly compiled kernel can then be installed. The kernel sources and build objects consume ~3GB.
 
-These scripts are for building the kernel for the 64-bit L4T 28.2 (Ubuntu 16.04 based) operating system on the NVIDIA Jetson TX2. The scripts should be run directly after flashing the Jetson with L4T 28.2.1 from a host PC. There are five scripts:
+These scripts are for building the kernel for the 64-bit L4T 32.1.0 (Ubuntu 18.04 based) operating system on the NVIDIA Jetson TX2. The scripts should be run directly after flashing the Jetson with L4T 32.1.0 from a host PC. There are five scripts:
 
 <strong>getKernelSources.sh</strong>
 
@@ -38,6 +38,10 @@ Special thanks to Raffaello Bonghi (https://github.com/rbonghi) for jetson_easy 
 Special thanks to Shreeyak (https://github.com/Shreeyak) for discussing alternatives to get source directly from NVIDIA git repositories.
 
 ### Release Notes
+May, 2019
+* vL4T32.1.0
+* L4T 32.1.0 (JetPack 4.2)
+
 July, 2018
 * vL4T28.2.1
 * L4T 28.2.1 (JetPack 3.2.1)

--- a/getKernelSources.sh
+++ b/getKernelSources.sh
@@ -7,7 +7,7 @@ echo "$JETSON_DESCRIPTION"
 echo "Jetpack $JETSON_JETPACK [L4T $JETSON_L4T]"
 
 # Check to make sure we're installing the correct kernel sources
-L4TTarget="28.2.1"
+L4TTarget="32.1.0"
 if [ $JETSON_L4T == $L4TTarget ] ; then
    echo "Getting kernel sources"
    sudo ./scripts/getKernelSources.sh

--- a/getKernelSourcesNoGUI.sh
+++ b/getKernelSourcesNoGUI.sh
@@ -7,7 +7,7 @@ echo "$JETSON_DESCRIPTION"
 echo "Jetpack $JETSON_JETPACK [L4T $JETSON_L4T]"
 
 # Check to make sure we're installing the correct kernel sources
-L4TTarget="28.2.1"
+L4TTarget="32.1.0"
 if [ $JETSON_L4T == $L4TTarget ] ; then
    echo "Getting kernel sources"
    sudo ./scripts/getKernelSourcesNoGUI.sh

--- a/removeAllKernelSources.sh
+++ b/removeAllKernelSources.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Remove all of the kernel sources that were downloaded and built during the kernel build process
 # Note that this will also remove the possibly changed .config file in:
-# /usr/src/kernel/kernel-4.4
+# /usr/src/kernel/kernel-4.9
 echo "Removing All Kernel Sources"
 sudo ./scripts/removeAllKernelSources.sh
 echo "Kernel sources removed"

--- a/scripts/copyImage.sh
+++ b/scripts/copyImage.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-cd /usr/src/kernel/kernel-4.4
+cd /usr/src/kernel/kernel-4.9
 # On the stock Jetson TX2 install, there is no zImage in the boot directory
 # So we just copy the Image file over
 # If the zImage is needed, you must either
 # $ make zImage
 # or
 # $ make
-# Both of these commands must be executed in /usr/src/kernel/kernel-4.4
+# Both of these commands must be executed in /usr/src/kernel/kernel-4.9
 # sudo cp arch/arm64/boot/zImage /boot/zImage
 # Note that if you are compiling on an external device, like a SSD, you should probably
 # copy this over to the internal eMMC if that is where the Jetson boots

--- a/scripts/getKernelSources.sh
+++ b/scripts/getKernelSources.sh
@@ -3,6 +3,6 @@
 source scripts/getKernelSourcesNoGUI.sh
 # We use QT 5 for the configuration GUI
 apt-get install qt5-default -y
-cd /usr/src/kernel/kernel-4.4
+cd /usr/src/kernel/kernel-4.9
 make xconfig
 

--- a/scripts/getKernelSourcesNoGUI.sh
+++ b/scripts/getKernelSourcesNoGUI.sh
@@ -4,8 +4,8 @@ apt-get update
 apt-get install pkg-config -y
 cd /usr/src
 wget -N https://developer.download.nvidia.com/embedded/L4T/r32_Release_v1.0/jax-tx2/BSP/JAX-TX2-public_sources.tbz2
-sudo tar -xvf JAX-TX2-public_sources.tbz2 public_release/kernel_src.tbz2
-tar -xvf public_release/kernel_src.tbz2
+sudo tar -xvf JAX-TX2-public_sources.tbz2 public_sources/kernel_src.tbz2
+tar -xvf public_sources/kernel_src.tbz2
 # Space is tight; get rid of the compressed kernel source
 rm -r public_release
 cd kernel/kernel-4.9

--- a/scripts/getKernelSourcesNoGUI.sh
+++ b/scripts/getKernelSourcesNoGUI.sh
@@ -4,7 +4,7 @@ apt-get update
 apt-get install pkg-config -y
 cd /usr/src
 wget -N https://developer.download.nvidia.com/embedded/L4T/r32_Release_v1.0/jax-tx2/BSP/JAX-TX2-public_sources.tbz2
-sudo tar -xvf public_sources.tbz2 public_release/kernel_src.tbz2
+sudo tar -xvf JAX-TX2-public_sources.tbz2 public_release/kernel_src.tbz2
 tar -xvf public_release/kernel_src.tbz2
 # Space is tight; get rid of the compressed kernel source
 rm -r public_release

--- a/scripts/getKernelSourcesNoGUI.sh
+++ b/scripts/getKernelSourcesNoGUI.sh
@@ -7,7 +7,7 @@ wget -N https://developer.download.nvidia.com/embedded/L4T/r32_Release_v1.0/jax-
 sudo tar -xvf JAX-TX2-public_sources.tbz2 public_sources/kernel_src.tbz2
 tar -xvf public_sources/kernel_src.tbz2
 # Space is tight; get rid of the compressed kernel source
-rm -r public_release
+rm -r public_sources
 cd kernel/kernel-4.9
 # Go get the default config file; this becomes the new system configuration
 zcat /proc/config.gz > .config

--- a/scripts/getKernelSourcesNoGUI.sh
+++ b/scripts/getKernelSourcesNoGUI.sh
@@ -3,12 +3,12 @@ apt-add-repository universe
 apt-get update
 apt-get install pkg-config -y
 cd /usr/src
-wget -N https://developer.download.nvidia.com/embedded/L4T/r28_Release_v2.1/public_sources.tbz2
+wget -N https://developer.download.nvidia.com/embedded/L4T/r32_Release_v1.0/jax-tx2/BSP/JAX-TX2-public_sources.tbz2
 sudo tar -xvf public_sources.tbz2 public_release/kernel_src.tbz2
 tar -xvf public_release/kernel_src.tbz2
 # Space is tight; get rid of the compressed kernel source
 rm -r public_release
-cd kernel/kernel-4.4
+cd kernel/kernel-4.9
 # Go get the default config file; this becomes the new system configuration
 zcat /proc/config.gz > .config
 

--- a/scripts/jetson_variables LICENSE
+++ b/scripts/jetson_variables LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Raffaello Bonghi
+Copyright (c) 2015-19 Raffaello Bonghi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/jetson_variables.sh
+++ b/scripts/jetson_variables.sh
@@ -66,6 +66,8 @@ if [ -f /etc/nv_tegra_release ]; then
     # https://developer.nvidia.com/embedded/jetpack-archive
     if [ "$JETSON_BOARD" = "TX2i" ] ; then 
         case $JETSON_L4T in
+            "32.1.0")
+                    JETSON_JETPACK="4.2" ;;
             "28.2.1")
                     JETSON_JETPACK="3.2.1" ;;
             "28.2") 
@@ -75,6 +77,8 @@ if [ -f /etc/nv_tegra_release ]; then
         esac        
     elif [ "$JETSON_BOARD" = "TX2" ] ; then
         case $JETSON_L4T in
+            "32.1.0")
+                    JETSON_JETPACK="4.2" ;;
             "28.2.1")
                     JETSON_JETPACK="3.2.1" ;;
             "28.2") 

--- a/scripts/makeKernel.sh
+++ b/scripts/makeKernel.sh
@@ -3,7 +3,7 @@
 # Assumes that the .config file is available in /proc/config.gz
 # Added check to see if make builds correctly; retry once if not
 
-cd /usr/src/kernel/kernel-4.4
+cd /usr/src/kernel/kernel-4.9
 make prepare
 make modules_prepare
 # Make alone will build the dts files too


### PR DESCRIPTION
Hi there!

First of all: Thanks for the awesome scripts! This repo dramatically reduced the pain for messing with the TX2 kernel for me.

Now to the PR:
Jetpack 4.2 for the TX2 (w/ L4T 32.1.0, Ubuntu 18.04.2, kernel 4.9.140) has been released.
As I had to patch my kernel I updated the scripts to support the new Jetpack version / L4T kernel.
I only tested it on my TX2, but it should also work on the TX2i.

I also modified the release notes in case you decide to merge and release it.